### PR TITLE
Update lib/wikipedia/page.rb

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -11,7 +11,7 @@ module Wikipedia
     end
 
     def content
-      page['revisions'].first.values.first if page['revisions']
+      page['revisions'].first.fetch('*') if page['revisions']
     end
 
     def sanitized_content


### PR DESCRIPTION
Content function was only showing content type 'text/x-wiki'
This fix shows the wiki-markup content.
