### PR TITLE
Fix page.rb content method

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -11,7 +11,7 @@ module Wikipedia
     end
 
     def content
-      page['revisions'].first.fetch('*') if page['revisions']
+      page['revisions'].first['*'] if page['revisions']
     end
 
     def sanitized_content


### PR DESCRIPTION
When pulling Wikipedia content "text/x-wiki" is returned. I'm using ruby 1.9.3p385 with rvm.

```
require 'wikipedia'
 => true

Wikipedia.find("Salesian High School").content
 => "text/x-wiki"
```

Fixed by changing page.rb to lookup key directly from hash.

```
page['revisions'].first["*"]
```

Now it responds with

```
require 'wikipedia'
 => true

 Wikipedia.find("Salesian High School").content
 => "'''Salesian School''' may refer to:\n\n* [[Salesian schools]],
a generic term applied to educational institutions run by the Roman
Catholic Salesian Congregation of Saint John Bosco\n....
```
