### PR TITLE
added image_descriptionurl method

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -57,6 +57,10 @@ module Wikipedia
       end
     end
 
+    def image_descriptionurl
+      page['imageinfo'].first['descriptionurl'] if page['imageinfo']
+    end    
+
     def raw_data
       @data
     end


### PR DESCRIPTION
Just implemented a method similar to image_url for calling the descriptionurl of an image.
This "description_url" page at wikipedia is where all the image metadata and info is listed.
