### PR TITLE
Fixed an issue with image_metadata

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -75,7 +75,7 @@ module Wikipedia
     def image_metadata
       unless @cached_image_metadata
         if list = images
-          filtered = list.select {|i| i =~ /^file:.+\.(jpg|jpeg|png|gif)$/i && !i.include?("LinkFA-star") }
+          filtered = list.select {|i| i =~ /^(F|f)ile:.+\.(jpg|jpeg|png|gif)$/i && !i.include?("LinkFA-star") }
           @cached_image_metadata = filtered.map {|title| Wikipedia.find_image(title) }
         end
       end


### PR DESCRIPTION
Some images weren't retrieved by the Page class because a regex was
restricting filenames to begin with downcase "file:", but not "File:"
