### PR TITLE
Added support for retrieving dutch image metadata

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -75,7 +75,7 @@ module Wikipedia
     def image_metadata
       unless @cached_image_metadata
         if list = images
-          filtered = list.select {|i| i =~ /^(F|f)ile:.+\.(jpg|jpeg|png|gif)$/i && !i.include?("LinkFA-star") }
+          filtered = list.select {|i| i =~ /^((B|b)estand|(F|f)ile):.+\.(jpg|jpeg|png|gif|svg)$/i && !i.include?("LinkFA-star") }
           @cached_image_metadata = filtered.map {|title| Wikipedia.find_image(title) }
         end
       end


### PR DESCRIPTION
Different languages of the wikipedia site return different names of image: the prefix "File:" is also translated.
For example, requesting image_urls when using the dutch wikipedia (nl.wikipedia.org) fails, image_metadata rejects the dutch prefix.

This commit enables support for dutch image metadata. 
