### PR TITLE
added page method to retrieve full url [like: /wiki/#{HTML_Escaped_Page_...

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -33,7 +33,9 @@ module Wikipedia
     end
 
     def fullurl
-      page['fullurl']
+        if self.raw_data["query"]["pages"].keys.length > 0
+            return "#{Wikipedia::Configuration['protocol']}://#{Wikipedia::Configuration['domain']}/wiki/#{URI.encode(self.title)}?curid=#{self.raw_data["query"]["pages"].keys[0]}"
+        end
     end
 
     def editurl


### PR DESCRIPTION
Hi!
retrieve a Page URL using `Page#fullurl` seems to not work anymore (always retrieves `nil`).
I changed it to correctly retrieve the Page URL from Wikipedia, using:
- configuration to generate the correct URL
- URI encode the page title
- appending curid

`#{protocol}://#{domain}/wiki/#{HTML_Escaped_Page_Title}?curid=#{curid}`

Note: Page title could be anything as soon as we provide a curid.
