### PR TITLE
Added thumb_url method to page

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -104,6 +104,8 @@ page.thumb_url
 Scale by height using `:iiurlheight` parameter.
 
 
+
+
 h2. Running specs
 
 if you have rspec >= 1.1.3 installed just type in

--- a/README.textile
+++ b/README.textile
@@ -103,8 +103,7 @@ page.thumb_url
 
 Scale by height using `:iiurlheight` parameter.
 
-
-
+</code></pre>
 
 h2. Running specs
 

--- a/README.textile
+++ b/README.textile
@@ -50,6 +50,10 @@ page.image_descriptionurls
 
 => ["http://en.wikipedia.org/wiki/File:Getting_Things_Done.jpg"]
 
+page.thumb_url
+
+=> ["http://upload.wikimedia.org/wikipedia/en/thumb/e/e1/Getting_Things_Done.jpg/100px-Getting_Things_Done.jpg"]
+
 page.coordinates
 
 => [48.853, 2.3498, "", "earth"]
@@ -87,6 +91,18 @@ page.raw_data
 => {"query"=>{"pages"=>{"959928"=>{"pageid"=>959928, "ns"=>0,
 "title"=>"Getting Things Done", "touched"=>"2010-03-10T00:04:09Z",
 "lastrevid"=>348481810, "counter"=>0, "length"=>7891}}}}</code></pre>
+
+
+To retrieve a scaled image thumbnail with 100px width:
+
+<pre><code>page = Wikipedia.find_image( "http://en.wikipedia.org/wiki/File:Getting_Things_Done.jpg", :iiurlwidth =>"100" )
+
+page.thumb_url
+
+=> ["http://upload.wikimedia.org/wikipedia/en/thumb/e/e1/Getting_Things_Done.jpg/100px-Getting_Things_Done.jpg"]
+
+Scale by height using `:iiurlheight` parameter.
+
 
 h2. Running specs
 

--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -76,6 +76,10 @@ module Wikipedia
       page['coordinates'].first.values if page['coordinates']
     end
 
+    def thumb_url
+      page['imageinfo'].first['thumburl'] if page['imageinfo']
+    end
+
     def raw_data
       @data
     end


### PR DESCRIPTION
Added `thumb_url` method to `page` to extract the thumb url when using the `find_image` method.

I included examples and usage in the `README.textile`

