### PR TITLE
add feature for find a random page.

### DIFF
--- a/lib/wikipedia.rb
+++ b/lib/wikipedia.rb
@@ -3,13 +3,13 @@ Dir[File.dirname(__FILE__) + '/wikipedia/**/*.rb'].each { |f| require f }
 require 'uri'
 
 module Wikipedia
-  # Examples : 
-  # page = Wikipedia.find('Rails') 
+  # Examples :
+  # page = Wikipedia.find('Rails')
   # => #<Wikipedia:0x123102>
   # page.content
   # => wiki content appears here
-  
-  # basically just a wrapper for doing 
+
+  # basically just a wrapper for doing
   # client = Wikipedia::Client.new
   # client.find('Rails')
   #
@@ -19,11 +19,14 @@ module Wikipedia
   def self.find_image( title, options = {} )
     client.find_image( title, options )
   end
-  
+  def self.find_random( options = {} )
+    client.find_random( options )
+  end
+
   def self.Configure(&block)
     Configuration.instance.instance_eval(&block)
   end
-  
+
   Configure {
     protocol  'http'
     domain    'en.wikipedia.org'

--- a/lib/wikipedia/client.rb
+++ b/lib/wikipedia/client.rb
@@ -23,6 +23,13 @@ module Wikipedia
       Page.new( request_image( title, options ) )
     end
 
+    def find_random( options = {} )
+      require 'json'
+      data = JSON::load( request_random( options ) )
+      title = data["query"]["pages"].values[0]["title"]
+      find( title, options )
+    end
+
     # http://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions%7Clinks%7Cimages%7Ccategories&rvprop=content&titles=Flower%20(video%20game)
     def request_page( title, options = {} )
       request( {
@@ -41,6 +48,16 @@ module Wikipedia
                  :prop => "imageinfo",
                  :iiprop => "url",
                  :titles => title
+               }.merge( options ) )
+    end
+
+    # http://en.wikipedia.org/w/api.php?action=query&generator=random&grnnamespace=0&prop=info
+    def request_random( options = {} )
+      request( {
+                 :action => "query",
+                 :generator => "random",
+                 :grnnamespace => "0",
+                 :prop => "info"
                }.merge( options ) )
     end
 

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -125,3 +125,15 @@ describe Wikipedia::Client, ".find page (Rails) at jp" do
     @page.should_not be_redirect
   end
 end
+
+describe Wikipedia::Client, ".find random page" do
+  before(:each) do
+    @client = Wikipedia::Client.new
+  end
+
+  it "should get random pages" do
+    @page1 = @client.find_random().title
+    @page2 = @client.find_random().title
+    @page1.should_not == @page2
+  end
+end


### PR DESCRIPTION
- lib/Wikipedia.find_random
  - alias for Wikipedia::Client.find_random.


- lib/Wikipedia::Client.find_random
  - get Wikipedia::Page object that take at random from the Wikipedia.
  - use Wikipedia::Client.request_random method.


- lib/Wikipedia::Client.request_random
  - get JSON string for random page's data by Wikipedia API.


- spec/lib/client_spec.rb
  - test for Wikipedia::Client.find_random.