### PR TITLE
check that page['extract'] exists before calling .split

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -45,7 +45,7 @@ module Wikipedia
     end
 
     def summary
-      (page['extract'].split("=="))[0].strip
+      (page['extract'].split("=="))[0].strip if page['extract']
     end
 
     def categories


### PR DESCRIPTION
With the example in the readme:

```ruby
page = Wikipedia.find "Getting Things Done"
```

then calling `page.summary` prints:

```txt
NoMethodError: undefined method `split' for nil:NilClass
from /home/max/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/wikipedia-client-1.6.2/lib/wikipedia/page.rb:48:in `summary'
```

the `summary` method is edited to just return `nil` and not raise an error