### PR TITLE
Made Wikipedia::Page#summary more robust for pagese without text

### DIFF
--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -7,7 +7,7 @@ module Wikipedia
     end
 
     def page
-      @data['query']['pages'].values.first
+      @data['query']['pages'].values.first if @data['query']['pages']
     end
 
     def content

--- a/lib/wikipedia/page.rb
+++ b/lib/wikipedia/page.rb
@@ -45,7 +45,7 @@ module Wikipedia
     end
 
     def summary
-      (page['extract'].split("=="))[0].strip if page['extract']
+      (page['extract'].split("=="))[0].strip if page['extract'] && page['extract'] != ''
     end
 
     def categories


### PR DESCRIPTION
Fixes `Wikipedia::Page#summary` for some pages without content, e.g. `Wikipedia.find("Wayne Forester").summary`.