### PR TITLE
Adds date requirement, updates lock version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wikipedia-client (1.6.1)
+    wikipedia-client (1.6.3)
 
 GEM
   remote: https://rubygems.org/
@@ -71,4 +71,4 @@ DEPENDENCIES
   wikipedia-client!
 
 BUNDLED WITH
-   1.10.5
+   1.15.0

--- a/README.textile
+++ b/README.textile
@@ -115,8 +115,6 @@ h3. Pushing a new release of the Gem
 
 Edit <code>lib/wikipedia/version.rb</code>, changing <code>VERSION</code>.
 
-Edit <code>wikipedia-client.gemspec</code>, changing <code>s.date</code> to today's date.
-
 Build the gem: <code>bundle exec gem build wikipedia-client.gemspec</code>
 
 Commit the changes: <code>git commit -a -m 'Version bump to 1.4.0' && git push</code>

--- a/wikipedia-client.gemspec
+++ b/wikipedia-client.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "wikipedia/version"
+require 'date'
 
 spec = Gem::Specification.new do |s|
   s.name    = "wikipedia-client"


### PR DESCRIPTION
- Imports date package to set date in gemspec
Without it:
```sh
wikipedia-client (master) > bundle exec rake spec

[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `wikipedia-client.gemspec`: uninitialized constant Date
Did you mean?  Data. Bundler cannot continue.

 #  from /Users/harmansingh/workplace/wikipedia-client/wikipedia-client.gemspec:13
 #  -------------------------------------------
 #    s.authors          = ["Cyril David", "Ken Pratt", "Mike Haugland", "Aishwarya Subramanian", "Pietro Menna", "Sophie Rapoport"]
 >    s.date             = Date.today.to_s
 #    s.description      = "Ruby client for the Wikipedia API"
 #  -------------------------------------------
. Bundler cannot continue.

 #  from /Users/harmansingh/workplace/wikipedia-client/Gemfile:2
 #  -------------------------------------------
 #  source 'https://rubygems.org'
 >  gemspec
 #  -------------------------------------------
 ```

- Removes date instruction line from README
Not needed now that it is set using `Date.today`

- Updates version in lock file to current

If I've messed something up here, do let me know, will push a change asap.