### PR TITLE
[tests] Updates expected image URLs

### DIFF
--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -113,7 +113,19 @@ describe Wikipedia::Client, ".find page (Edsger_Dijkstra)" do
   it "should collect the image urls" do
     @client.follow_redirects = true
     @page = @client.find('Edsger Dijkstra')
-    @page.image_urls.should == ["https://upload.wikimedia.org/wikipedia/en/4/4a/Commons-logo.svg", "https://upload.wikimedia.org/wikipedia/commons/5/57/Dijkstra_Animation.gif", "https://upload.wikimedia.org/wikipedia/commons/6/6a/Dining_philosophers.png", "https://upload.wikimedia.org/wikipedia/commons/c/c9/Edsger_Dijkstra_1994.jpg", "https://upload.wikimedia.org/wikipedia/commons/d/d9/Edsger_Wybe_Dijkstra.jpg", "https://upload.wikimedia.org/wikipedia/en/4/48/Folder_Hexagonal_Icon.svg", "https://upload.wikimedia.org/wikipedia/commons/7/7b/Rail-semaphore-signal-Dave-F.jpg", "https://upload.wikimedia.org/wikipedia/commons/2/21/Speaker_Icon.svg", "https://upload.wikimedia.org/wikipedia/commons/f/fa/Wikiquote-logo.svg"]
+    [
+      '/en/4/4a/Commons-logo.svg',
+      '/en/4/48/Folder_Hexagonal_Icon.svg',
+      '/commons/5/57/Dijkstra_Animation.gif',
+      '/commons/c/c9/Edsger_Dijkstra_1994.jpg',
+      '/commons/d/d9/Edsger_Wybe_Dijkstra.jpg',
+      '/commons/0/00/Complex-adaptive-system.jpg',
+      '/en/4/4d/Centrum-wiskunde-informatica-logo.png',
+      '/commons/7/7b/An_illustration_of_the_dining_philosophers_problem.png',
+      '/commons/3/37/Detail_of_a_1Kb_ferrite_core_RAM-module_of_an_1960s_Electrologica_X1_computer.jpg'
+    ].each do |image|
+      @page.image_urls.should include('https://upload.wikimedia.org/wikipedia' + image)
+    end
   end
 end
 


### PR DESCRIPTION
Ref: #53 

Wikipedia image URL collection tests was failing due to the URL list being out-of-date.

This updates the list, and shortens the line too.