### PR TITLE
[build] Fixes build exit code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ end
 desc 'Test the wikipedia plugin.'
 task :spec do
   spec_path = File.expand_path(File.dirname(__FILE__) + '/spec/**/*.rb')
-  system("rspec -cfs #{spec_path}")
+  exec("rspec -cfs #{spec_path}")
 end
 
 begin


### PR DESCRIPTION
Ref: #56 - Travis builds never fail, even when tests do

Turns out this is an issue with the way we're calling `rspec`.
We're using `system` to call `rspec` in the Rakefile, but not checking its return value. 

As I learnt [here](https://stackoverflow.com/a/18728230/5612201) `system` returns false if the command returns a non-zero exit code. The rake task itself passes, because the error got encapsulated in `system`.

I've fixed this for now by using `exec` instead of `system`. [This seems to be working](https://travis-ci.org/harman28/wikipedia-client/builds/235292561).
> The command "bundle exec rake" exited with 1.

Also works on local.
```sh
wikipedia-client (development) > bundle exec rake 
...
failures
...
Finished in 2.33 seconds
38 examples, 1 failures

Failed examples:

rspec ./spec/lib/client_spec.rb:69 # Wikipedia::Client.find page with one section (mocked) test that is meant to fail
wikipedia-client (development) > echo $?
1
```