### PR TITLE
[rake] Improves the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,38 +1,20 @@
-$:.push File.expand_path("../lib", __FILE__)
-require 'rubygems'
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'rake'
+require 'rspec/core/rake_task'
 
-require 'rake/testtask'
-Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
-end
-
+task default: :spec
 
 desc 'Test the wikipedia plugin.'
-task :spec do
-  spec_path = File.expand_path(File.dirname(__FILE__) + '/spec/**/*.rb')
-  exec("rspec -cfs #{spec_path}")
-end
+RSpec::Core::RakeTask.new(:spec)
 
-begin
-  require 'rcov/rcovtask'
-  Rcov::RcovTask.new do |test|
-    test.libs << 'test'
-    test.pattern = 'test/**/test_*.rb'
-    test.verbose = true
-  end
-rescue LoadError
-  task :rcov do
-    abort "RCov is not available. In order to run rcov, you must: sudo gem install spicycode-rcov"
-  end
+desc 'Run spec with coverage'
+task :coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task['spec'].execute
 end
-
-task :default => :spec
 
 require 'rdoc/task'
-require "wikipedia/version"
+require 'wikipedia/version'
 Rake::RDocTask.new do |rdoc|
   version = Wikipedia::VERSION
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,12 @@
-require 'rubygems'
 require 'rspec'
+
+if ENV['COVERAGE'] == 'true'
+  begin
+    require 'simplecov'
+    SimpleCov.start
+  rescue LoadError
+    abort 'Coverage driver not available. In order to run coverage, you must run: gem install simplecov'
+  end
+end
 
 require File.dirname(__FILE__) + '/../lib/wikipedia'


### PR DESCRIPTION
* Replaces `rcov` with `simplecov`
`spicycode-rcov` hasn't been maintained for 8 years now, and `rcov` for 5. Simplecov is a good replacement. Added as a non-dependency.
* Uses default rake spec rake task definition (`RSpec::Core::RakeTask`), to avoid `exec`
* Removes unnecessary `rubygems` requirement
   - [Why "require 'rubygems'" Is Wrong](https://2ndscale.com/rtomayko/2009/require-rubygems-antipattern)
   - [RubyGems Guides: Requiring Rubygems](http://guides.rubygems.org/patterns/#requiring_rubygems)
* Removes unused task `rake test`

These changes are also present in #54 , but that's a large PR already, and I don't want to mix general improvements with Rubocop-suggested ones.