### PR TITLE
Updated 'json' dependency so it works with Ruby 2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       nokogiri (= 1.5.10)
       rake
       rdoc
-    json (1.8.3)
+    json (1.8.6)
     jwt (0.1.8)
       multi_json (>= 1.5)
     multi_json (1.8.1)


### PR DESCRIPTION
json 1.8.3 is not compatible with Ruby 2.4. More details [here](https://github.com/flori/json/issues/303).

This PR uses a higher version which is compatible with Ruby 2.4.