### PR TITLE
Added proper escaping for '+' in titles, escaping spec

### DIFF
--- a/lib/wikipedia/client.rb
+++ b/lib/wikipedia/client.rb
@@ -105,7 +105,7 @@ module Wikipedia
     def encode( val )
       case val
       when String
-        URI.encode( val ).gsub( '&', '%26' )
+        URI.encode( val, /#{URI::UNSAFE}|[\+&]/ )
       else
         val
       end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -90,6 +90,15 @@ describe Wikipedia::Client, '.find page with one section (mocked)' do
   end
 end
 
+describe Wikipedia::Client, '.find page with special characters in title' do
+  it 'should properly escaped the special characters' do
+    @client = Wikipedia::Client.new
+    @page = @client.find('A +&%=?:/ B')
+    expect(@page.title).to eq('A +&%=?:/ B')
+    expect(@page.fullurl).to eq('https://en.wikipedia.org/wiki/A_%2B%26%25%3D%3F:/_B')
+  end
+end
+
 describe Wikipedia::Client, '.find image (mocked)' do
   before(:each) do
     @client = Wikipedia::Client.new


### PR DESCRIPTION
The library doesn't properly escape `+` in article titles. I came across this when I asked for the article for C++, and the article for the letter C:

```
$ ruby -r wikipedia -e 'p Wikipedia.find("C++").title'
"C"
```

This PR fixes the problem and adds a spec for it.