### PR TITLE
Slash fix

### DIFF
--- a/lib/wikipedia/url.rb
+++ b/lib/wikipedia/url.rb
@@ -8,7 +8,7 @@ module Wikipedia
       return @title if @title
 
       uri     = URI.parse( @wiki_url )
-      @title  = URI.decode( uri.path.split('/').last )
+      @title  = URI.decode( uri.path.sub(%r{^/wiki/}, '') )
     end
   end
 end

--- a/lib/wikipedia/url.rb
+++ b/lib/wikipedia/url.rb
@@ -8,7 +8,7 @@ module Wikipedia
       return @title if @title
 
       uri     = URI.parse( @wiki_url )
-      @title  = URI.decode( uri.path.sub(%r{^/wiki/}, '') )
+      @title  = URI.decode( uri.path.sub(/\/wiki\//, '') )
     end
   end
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -106,6 +106,12 @@ describe Wikipedia::Client, '.find page with special characters in title' do
     expect(@page.title).to eq('C++')
     expect(@page.fullurl).to eq('https://en.wikipedia.org/wiki/C%2B%2B')
   end
+
+  it 'should handle slashes in article titles' do
+    @page = @client.find('PL/SQL')
+    expect(@page.title).to eq('PL/SQL')
+    expect(@page.fullurl).to eq('https://en.wikipedia.org/wiki/PL/SQL')
+  end
 end
 
 describe Wikipedia::Client, '.find image (mocked)' do

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -91,11 +91,20 @@ describe Wikipedia::Client, '.find page with one section (mocked)' do
 end
 
 describe Wikipedia::Client, '.find page with special characters in title' do
-  it 'should properly escaped the special characters' do
+  before(:each) do
     @client = Wikipedia::Client.new
+  end
+
+  it 'should properly escape all special characters' do
     @page = @client.find('A +&%=?:/ B')
     expect(@page.title).to eq('A +&%=?:/ B')
     expect(@page.fullurl).to eq('https://en.wikipedia.org/wiki/A_%2B%26%25%3D%3F:/_B')
+  end
+
+  it 'should handle pluses in article titles' do
+    @page = @client.find('C++')
+    expect(@page.title).to eq('C++')
+    expect(@page.fullurl).to eq('https://en.wikipedia.org/wiki/C%2B%2B')
   end
 end
 


### PR DESCRIPTION
This fixes the handling of article titles containing slashes, which Wikipedia canonicalizes as if the slash were part of a path, e.g. `https://en.wikipedia.org/wiki/PL/SQL`.

This changes how `Url` extracts titles; it now specifically looks for the `/wiki/` prefix. The specs still pass, but let me know if that change is going to break something.

(I discovered #76 pointing at the C++ article; this one comes from PL/SQL. Guess what topic my little Wikipedia project involves….)