### PR TITLE
replace obsolete URI.encode with CGI.escape

### DIFF
--- a/lib/wikipedia/client.rb
+++ b/lib/wikipedia/client.rb
@@ -106,7 +106,7 @@ module Wikipedia
     def encode( val )
       case val
       when String
-        URI.encode( val, /#{URI::UNSAFE}|[\+&]/ )
+        CGI.escape(val)
       else
         val
       end


### PR DESCRIPTION
Ruby 3 got rid of the long-deprecated `URI.encode`