### PR TITLE
Add addressable dependency to gemspec

### DIFF
--- a/wikipedia-client.gemspec
+++ b/wikipedia-client.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |s|
 
   s.require_paths    << 'lib'
   s.rdoc_options     << '--title' << 'wikipedia-client' << '--main' << '-ri'
+
+  s.add_runtime_dependency "addressable", "~> 2.7"
 end

--- a/wikipedia-client.gemspec
+++ b/wikipedia-client.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.require_paths    << 'lib'
   s.rdoc_options     << '--title' << 'wikipedia-client' << '--main' << '-ri'
 
-  s.add_runtime_dependency "addressable", "~> 2.7"
+  s.add_runtime_dependency 'addressable', '~> 2.7'
 end


### PR DESCRIPTION
Current released version does not work, since the gemspec does not include `addressable`... 🤦 

The tests passed even without it, since the `jewler` gem brings it as a sub-dependency.