### PR TITLE
Allow to use different configurations in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/wikipedia-client.svg)](https://badge.fury.io/rb/wikipedia-client)
 [![Build Status](https://github.com/kenpratt/wikipedia-client/workflows/Test/badge.svg)](https://github.com/kenpratt/wikipedia-client/actions?query=workflow%3ATest)
 
-
 Allows you to get wikipedia content through their API. This uses the
 alpha API, not the deprecated query.php API type.
 
@@ -80,6 +79,7 @@ page.langlinks
 ## Configuration
 
 ### Global
+
 This is by default configured like this:
 
 ```ruby
@@ -90,19 +90,19 @@ Wikipedia.configure {
 ```
 
 ### Local
+
 If you need to query multiple wikis indiviual clients with individual configurations can be
 used:
 
 ```ruby
-config_en = Wikipedia::Config.new(domain: 'en.wikipedia.org', path: 'w/api.php')
-config_de = Wikipedia::Config.new(domain: 'de.wikipedia.org', path: 'w/api.php')
+config_en = Wikipedia::Configuration.new(domain: 'en.wikipedia.org', path: 'w/api.php')
+config_de = Wikipedia::Configuration.new(domain: 'de.wikipedia.org', path: 'w/api.php')
 
 client_en = Wikipedia::Client.new(config_en)
 client_de = Wikipedia::Client.new(config_de)
 client_en.find( 'Getting Things Done' )
 client_de.find( 'Buch' )
 ```
-
 
 ## Advanced
 
@@ -139,15 +139,19 @@ bundle exec rspec
 
 1. Edit `lib/wikipedia/version.rb`, changing `VERSION`.
 2. Test that the current branch will work as a gem, by testing in an external directory:
-  1. Make a test directory.
-  2. Add a `Gemfile` with:
+3. Make a test directory.
+4. Add a `Gemfile` with:
+
+
     ```
     source 'https://rubygems.org'
 
     gem 'wikipedia-client', :path => '/path/to/local/wikipedia-client'
     ```
 
-  3. And a `test.rb` file with:
+3. And a `test.rb` file with:
+
+
     ```
     require 'wikipedia'
 
@@ -155,20 +159,24 @@ bundle exec rspec
     puts page.title
     ```
 
-  4. And then run `bundle install && bundle exec ruby test.rb`
-3. Build the gem: `bundle exec gem build wikipedia-client.gemspec`.
-4. Commit the changes: `git commit -a -m 'Version bump to 1.4.0' && git tag v1.4.0 && git push && git push --tag`
-5. Publish the result to RubyGems: `bundle exec gem push wikipedia-client-1.4.0.gem`.
-6. Test the released gem in an external directory:
-  1. Make a test directory.
-  2. Add a `Gemfile` with:
+4. And then run `bundle install && bundle exec ruby test.rb`
+5. Build the gem: `bundle exec gem build wikipedia-client.gemspec`.
+6. Commit the changes: `git commit -a -m 'Version bump to 1.4.0' && git tag v1.4.0 && git push && git push --tag`
+7. Publish the result to RubyGems: `bundle exec gem push wikipedia-client-1.4.0.gem`.
+8. Test the released gem in an external directory:
+9. Make a test directory.
+10. Add a `Gemfile` with:
+
+
     ```
     source 'https://rubygems.org'
 
     gem 'wikipedia-client'
     ```
 
-  3. And a `test.rb` file with:
+3. And a `test.rb` file with:
+
+
     ```
     require 'wikipedia'
 
@@ -176,7 +184,7 @@ bundle exec rspec
     puts page.title
     ```
 
-  4. And then run `bundle install && bundle exec ruby test.rb`
+4. And then run `bundle install && bundle exec ruby test.rb`
 
 ## Thanks!
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ If you need to query multiple wikis indiviual clients with individual configurat
 used:
 
 ```ruby
-config_en = Wikipedia::Configuration.new(domain: 'en.wikipedia.org', path: 'w/api.php')
-config_de = Wikipedia::Configuration.new(domain: 'de.wikipedia.org', path: 'w/api.php')
+config_en = Wikipedia::Configuration.new(domain: 'en.wikipedia.org')
+config_de = Wikipedia::Configuration.new(domain: 'de.wikipedia.org')
 
 client_en = Wikipedia::Client.new(config_en)
 client_de = Wikipedia::Client.new(config_de)
@@ -142,31 +142,28 @@ bundle exec rspec
 3. Make a test directory.
 4. Add a `Gemfile` with:
 
+   ```
+   source 'https://rubygems.org'
 
-    ```
-    source 'https://rubygems.org'
+   gem 'wikipedia-client', :path => '/path/to/local/wikipedia-client'
+   ```
 
-    gem 'wikipedia-client', :path => '/path/to/local/wikipedia-client'
-    ```
+5. And a `test.rb` file with:
 
-3. And a `test.rb` file with:
+   ```
+   require 'wikipedia'
 
+   page = Wikipedia.find('Ruby')
+   puts page.title
+   ```
 
-    ```
-    require 'wikipedia'
-
-    page = Wikipedia.find('Ruby')
-    puts page.title
-    ```
-
-4. And then run `bundle install && bundle exec ruby test.rb`
-5. Build the gem: `bundle exec gem build wikipedia-client.gemspec`.
-6. Commit the changes: `git commit -a -m 'Version bump to 1.4.0' && git tag v1.4.0 && git push && git push --tag`
-7. Publish the result to RubyGems: `bundle exec gem push wikipedia-client-1.4.0.gem`.
-8. Test the released gem in an external directory:
-9. Make a test directory.
-10. Add a `Gemfile` with:
-
+6. And then run `bundle install && bundle exec ruby test.rb`
+7. Build the gem: `bundle exec gem build wikipedia-client.gemspec`.
+8. Commit the changes: `git commit -a -m 'Version bump to 1.4.0' && git tag v1.4.0 && git push && git push --tag`
+9. Publish the result to RubyGems: `bundle exec gem push wikipedia-client-1.4.0.gem`.
+10. Test the released gem in an external directory:
+11. Make a test directory.
+12. Add a `Gemfile` with:
 
     ```
     source 'https://rubygems.org'
@@ -174,8 +171,7 @@ bundle exec rspec
     gem 'wikipedia-client'
     ```
 
-3. And a `test.rb` file with:
-
+13. And a `test.rb` file with:
 
     ```
     require 'wikipedia'
@@ -184,7 +180,7 @@ bundle exec rspec
     puts page.title
     ```
 
-4. And then run `bundle install && bundle exec ruby test.rb`
+14. And then run `bundle install && bundle exec ruby test.rb`
 
 ## Thanks!
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ page.langlinks
 
 ## Configuration
 
+### Global
 This is by default configured like this:
 
 ```ruby
@@ -87,6 +88,21 @@ Wikipedia.configure {
   path   'w/api.php'
 }
 ```
+
+### Local
+If you need to query multiple wikis indiviual clients with individual configurations can be
+used:
+
+```ruby
+config_en = Wikipedia::Config.new(domain: 'en.wikipedia.org', path: 'w/api.php')
+config_de = Wikipedia::Config.new(domain: 'de.wikipedia.org', path: 'w/api.php')
+
+client_en = Wikipedia::Client.new(config_en)
+client_de = Wikipedia::Client.new(config_de)
+client_en.find( 'Getting Things Done' )
+client_de.find( 'Buch' )
+```
+
 
 ## Advanced
 
@@ -116,7 +132,7 @@ page.raw_data
 git clone git@github.com:kenpratt/wikipedia-client.git
 cd wikipedia-client
 bundle install
-bundle exec spec
+bundle exec rspec
 ```
 
 ### Pushing a new release of the Gem

--- a/lib/wikipedia.rb
+++ b/lib/wikipedia.rb
@@ -24,7 +24,7 @@ module Wikipedia
   end
 
   def self.configure(&block)
-    Configuration.instance.instance_eval(&block)
+    @configuration.instance_eval(&block)
   end
 
   # rubocop:disable Style/MethodName
@@ -32,20 +32,12 @@ module Wikipedia
     configure(&block)
   end
 
-  configure do
-    protocol  'https'
-    domain    'en.wikipedia.org'
-    path      'w/api.php'
-    user_agent(
-      'wikipedia-client/1.7 (https://github.com/kenpratt/wikipedia-client)'
-    )
-  end
-
   class << self
     private
 
     def client
-      @client ||= Wikipedia::Client.new
+      @configuration ||= Wikipedia::Configuration.new
+      @client ||= Wikipedia::Client.new @configuration
     end
   end
 end

--- a/lib/wikipedia/client.rb
+++ b/lib/wikipedia/client.rb
@@ -11,7 +11,8 @@ module Wikipedia
 
     attr_accessor :follow_redirects
 
-    def initialize
+    def initialize(configuration = Wikipedia::Configuration.new)
+      @configuration = configuration
       self.follow_redirects = true
     end
 
@@ -72,16 +73,16 @@ module Wikipedia
     end
 
     def request( options )
-      URI.parse( url_for( options ) ).read( 'User-Agent' => Configuration[:user_agent] )
+      URI.parse( url_for( options ) ).read( 'User-Agent' => @configuration[:user_agent] )
     end
 
     protected
 
     def configuration_options
       {
-        protocol: Configuration[:protocol],
-        domain:   Configuration[:domain],
-        path:     Configuration[:path]
+        protocol: @configuration[:protocol],
+        domain:   @configuration[:domain],
+        path:     @configuration[:path]
       }
     end
 

--- a/lib/wikipedia/configuration.rb
+++ b/lib/wikipedia/configuration.rb
@@ -5,10 +5,10 @@ module Wikipedia
       domain: 'en.wikipedia.org',
       path: 'w/api.php',
       user_agent: 'wikipedia-client/1.7 (https://github.com/kenpratt/wikipedia-client)'
-    }
+    }.freeze
 
     def initialize(configuration = DEFAULT)
-      configuration.each { |args| send(*args) }
+      DEFAULT.merge(configuration).each { |args| send(*args) }
     end
 
     def [](directive)

--- a/lib/wikipedia/configuration.rb
+++ b/lib/wikipedia/configuration.rb
@@ -8,7 +8,7 @@ module Wikipedia
     }
 
     def initialize(configuration = DEFAULT)
-      configuration.each { |args| self.send(*args) }
+      configuration.each { |args| send(*args) }
     end
 
     def [](directive)

--- a/lib/wikipedia/configuration.rb
+++ b/lib/wikipedia/configuration.rb
@@ -1,8 +1,19 @@
-require 'singleton'
-
 module Wikipedia
   class Configuration
-    include Singleton
+    DEFAULT = {
+      protocol: 'https',
+      domain: 'en.wikipedia.org',
+      path: 'w/api.php',
+      user_agent: 'wikipedia-client/1.7 (https://github.com/kenpratt/wikipedia-client)'
+    }
+
+    def initialize(configuration = DEFAULT)
+      configuration.each { |args| self.send(*args) }
+    end
+
+    def [](directive)
+      send(directive)
+    end
 
     def self.directives(*directives)
       directives.each do |directive|
@@ -12,10 +23,6 @@ module Wikipedia
           instance_variable_set("@#{directive}", args.first)
         end
       end
-    end
-
-    def self.[](directive)
-      instance.send(directive)
     end
 
     directives :protocol, :domain, :path, :user_agent


### PR DESCRIPTION
I need to run multiple clients with different configurations. As I understand the current implementation the configuration is a "global" singleton class. Hence, each instance of `Client` uses the same Instnace of `Configuration`. With this pull request, I tried to fix that without breaking the original API.