### PR TITLE
Add helper for bundler to auto require

### DIFF
--- a/lib/wikipedia-client.rb
+++ b/lib/wikipedia-client.rb
@@ -1,0 +1,2 @@
+# rubocop:disable Style/FileName
+require 'wikipedia'


### PR DESCRIPTION
Currently, if we add `wikipedia-client` via bundler, since the name of this gem and the class differs, bundler's auto require mechanism fails, and we need to manually add `require 'wikipedia'`. 

This pull request adds a simple helper to make auto require work.