### PR TITLE
Initialize configuration before configure

### DIFF
--- a/lib/wikipedia.rb
+++ b/lib/wikipedia.rb
@@ -24,7 +24,7 @@ module Wikipedia
   end
 
   def self.configure(&block)
-    @configuration.instance_eval(&block)
+    configuration.instance_eval(&block)
   end
 
   # rubocop:disable Style/MethodName
@@ -35,9 +35,12 @@ module Wikipedia
   class << self
     private
 
-    def client
+    def configuration
       @configuration ||= Wikipedia::Configuration.new
-      @client ||= Wikipedia::Client.new @configuration
+    end
+
+    def client
+      @client ||= Wikipedia::Client.new configuration
     end
   end
 end

--- a/spec/lib/wikipedia_spec.rb
+++ b/spec/lib/wikipedia_spec.rb
@@ -18,3 +18,15 @@ describe Wikipedia, '.find' do
     expect(page1.title).to eq(page2.title)
   end
 end
+
+describe Wikipedia, '.configure' do
+  it 'should set configuration' do
+    Wikipedia.configure do
+      protocol 'https'
+      domain 'zh.wikipedia.org'
+    end
+
+    page = Wikipedia.find('Getting_Things_Done')
+    expect(page.fullurl).to start_with('https://zh.wikipedia.org')
+  end
+end


### PR DESCRIPTION
Though current implementation provides a `configure` API, It raises no configuration exception unless we call any APIs to build up client & configuration instances.