### PR TITLE
Allow headers customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,29 @@ page.raw_data
 "lastrevid"=>348481810, "counter"=>0, "length"=>7891}}}}
 ```
 
+### Additional HTTP headers
+
+Some API features require tweaking HTTP headers. You can add additional headers via configuration.
+
+For example, to retrieve the same page in different language variants:
+
+```ruby
+Wikipedia.configure do
+   domain 'zh.wikipedia.org'
+   headers({ 'Accept-Language' => 'zh-tw' })
+end
+
+Wikipedia.find('牛肉').summary #=> "牛肉是指從牛身上得出的肉，為常見的肉品之一。肌肉部分可以切成牛排、牛肉塊或牛仔骨，也可以與其他的肉混合做成香腸或血腸。"
+
+Wikipedia.configure do
+   domain 'zh.wikipedia.org'
+   headers({ 'Accept-Language' => 'zh-cn' })
+end
+
+Wikipedia.find('牛肉').summary #=> "牛肉是指从牛身上得出的肉，为常见的肉品之一。肌肉部分可以切成牛排、牛肉块或牛仔骨，也可以与其他的肉混合做成香肠或血肠。"
+```
+
+
 ## Contributing
 
 ### Getting the code, and running the tests

--- a/lib/wikipedia/client.rb
+++ b/lib/wikipedia/client.rb
@@ -73,7 +73,7 @@ module Wikipedia
     end
 
     def request( options )
-      URI.parse( url_for( options ) ).read( 'User-Agent' => @configuration[:user_agent] )
+      URI.parse( url_for( options ) ).read( headers )
     end
 
     protected
@@ -113,6 +113,12 @@ module Wikipedia
         (keys.include?(k) ? h1 : h2).store(k, v)
       end
       [h1, h2]
+    end
+
+    def headers
+      {
+        'User-Agent' => @configuration[:user_agent]
+      }.merge( @configuration[:headers] )
     end
   end
 end

--- a/lib/wikipedia/configuration.rb
+++ b/lib/wikipedia/configuration.rb
@@ -4,7 +4,8 @@ module Wikipedia
       protocol: 'https',
       domain: 'en.wikipedia.org',
       path: 'w/api.php',
-      user_agent: 'wikipedia-client/1.7 (https://github.com/kenpratt/wikipedia-client)'
+      user_agent: 'wikipedia-client/1.7 (https://github.com/kenpratt/wikipedia-client)',
+      headers: {}
     }.freeze
 
     def initialize(configuration = DEFAULT)
@@ -25,6 +26,6 @@ module Wikipedia
       end
     end
 
-    directives :protocol, :domain, :path, :user_agent
+    directives :protocol, :domain, :path, :user_agent, :headers
   end
 end


### PR DESCRIPTION
For language with variants, `accept-language` header is the way to get results in different language variants.

```ruby
Wikipedia.configure do
   domain 'zh.wikipedia.org'
   headers({ 'Accept-Language' => 'zh-tw' })
end

Wikipedia.find('牛肉').summary #=> "牛肉是指從牛身上得出的肉，為常見的肉品之一。肌肉部分可以切成牛排、牛肉塊或牛仔骨，也可以與其他的肉混合做成香腸或血腸。"

Wikipedia.configure do
   domain 'zh.wikipedia.org'
   headers({ 'Accept-Language' => 'zh-cn' })
end

Wikipedia.find('牛肉').summary #=> "牛肉是指从牛身上得出的肉，为常见的肉品之一。肌肉部分可以切成牛排、牛肉块或牛仔骨，也可以与其他的肉混合做成香肠或血肠。"
```