### PR TITLE
Add modern Rubies and get to green

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
     strategy:
-      matrix: { ruby: ['2.5', '2.6', '2.7', '3.0'] }
+      matrix: { ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2'] }
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,13 +8,13 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 15
 
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: false
 
 Style/RescueModifier:
   Enabled: false
 
-Style/SpaceInsidePercentLiteralDelimiters:
+Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 
 Style/RegexpLiteral:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,3 +77,6 @@ Gemspec/RequiredRubyVersion:
 
 Style/Encoding:
   Enabled: false
+
+Lint/NonDeterministicRequireOrder:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  NewCops: disable
+
 Metrics/LineLength:
   Max: 120
   AllowURI: true
@@ -25,3 +28,52 @@ Style/SymbolArray:
 
 Metrics/ClassLength:
   Max: 130
+
+# TODO: Remove each of the rules below once fixed.
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Lint/MissingCopEnableDirective:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
+  Enabled: false
+
+Naming/MethodParameterName:
+  Enabled: false
+
+Style/RedundantAssignment:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/LeadingEmptyLines:
+  Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake'
 gem 'rdoc'
 gem 'rspec'
 # FIXME: Remove rubocop version restriction and fix or disable cops
-gem 'rubocop', '= 0.48.1'
+gem 'rubocop', '~> 1.22', require: false
 gem 'thoughtbot-shoulda'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'jeweler'
 gem 'pry'
 gem 'rake'
 gem 'rdoc'

--- a/lib/wikipedia-client.rb
+++ b/lib/wikipedia-client.rb
@@ -1,2 +1,2 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 require 'wikipedia'

--- a/lib/wikipedia.rb
+++ b/lib/wikipedia.rb
@@ -27,7 +27,7 @@ module Wikipedia
     configuration.instance_eval(&block)
   end
 
-  # rubocop:disable Style/MethodName
+  # rubocop:disable Naming/MethodName
   def self.Configure(&block)
     configure(&block)
   end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -160,7 +160,6 @@ describe Wikipedia::Client, '.find page (Edsger_Dijkstra)' do
     @client.follow_redirects = true
     @page = @client.find('Edsger Dijkstra')
     [
-      '/commons/5/57/Dijkstra_Animation.gif',
       '/commons/c/c9/Edsger_Dijkstra_1994.jpg',
       '/commons/d/d9/Edsger_Wybe_Dijkstra.jpg'
     ].each do |image|
@@ -172,7 +171,6 @@ describe Wikipedia::Client, '.find page (Edsger_Dijkstra)' do
     @client.follow_redirects = true
     @page = @client.find('Edsger Dijkstra')
     [
-      '/commons/thumb/5/57/Dijkstra_Animation.gif/200px-Dijkstra_Animation.gif',
       '/commons/thumb/c/c9/Edsger_Dijkstra_1994.jpg/200px-Edsger_Dijkstra_1994.jpg',
       '/commons/thumb/d/d9/Edsger_Wybe_Dijkstra.jpg/200px-Edsger_Wybe_Dijkstra.jpg'
     ].each do |image|
@@ -184,7 +182,6 @@ describe Wikipedia::Client, '.find page (Edsger_Dijkstra)' do
     @client.follow_redirects = true
     @page = @client.find('Edsger Dijkstra')
     [
-      '/commons/thumb/5/57/Dijkstra_Animation.gif/100px-Dijkstra_Animation.gif',
       '/commons/thumb/c/c9/Edsger_Dijkstra_1994.jpg/100px-Edsger_Dijkstra_1994.jpg',
       '/commons/thumb/d/d9/Edsger_Wybe_Dijkstra.jpg/100px-Edsger_Wybe_Dijkstra.jpg'
     ].each do |image|

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -195,7 +195,7 @@ describe Wikipedia::Client, '.find page (Edsger_Dijkstra)' do
   it 'should collect the main image thumburl' do
     @client.follow_redirects = true
     @page = @client.find('Edsger Dijkstra')
-    image = '/commons/thumb/d/d9/Edsger_Wybe_Dijkstra.jpg/150px-Edsger_Wybe_Dijkstra.jpg'
+    image = '/commons/thumb/d/d9/Edsger_Wybe_Dijkstra.jpg/200px-Edsger_Wybe_Dijkstra.jpg'
     expect(@page.main_image_thumburl).to include('https://upload.wikimedia.org/wikipedia' + image)
   end
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 require 'json'
 
-# rubocop:disable Metrics/BlockLength
 describe Wikipedia::Client, '.find page (mocked)' do
   before(:each) do
     @client = Wikipedia::Client.new


### PR DESCRIPTION
This is a PR that builds on #110 .  In addition to the changes in that PR (whose commits were pulled in) it:

1. Adds Ruby 3.1 and 3.2 to the CI matrix
2. Updates the checkout action version
3. Updates a few tests to accomodate changes in the Wikipedia content

It runs green on my fork.